### PR TITLE
Relax source-location annotation validation

### DIFF
--- a/src/schemas/annotations.schema.json
+++ b/src/schemas/annotations.schema.json
@@ -48,7 +48,7 @@
               "properties": {
                 "backstage.io/source-location": {
                   "type": "string",
-                  "pattern": "(url|gitlab|github|azure\/api|dir):.*$"
+                  "pattern": "((url|gitlab|github|azure\/api):.*|(dir):.*\/)$"
                 }
               }
             },

--- a/src/schemas/annotations.schema.json
+++ b/src/schemas/annotations.schema.json
@@ -48,7 +48,7 @@
               "properties": {
                 "backstage.io/source-location": {
                   "type": "string",
-                  "pattern": "(url|gitlab|github|azure\/api|dir):.*\/$"
+                  "pattern": "(url|gitlab|github|azure\/api|dir):.*$"
                 }
               }
             },


### PR DESCRIPTION
**Problem**

Some links that we use do not have a trailing slash at the end.  Adding the trailing slash to these URLs results in a 404.

**Solution**

Remove the required trailing slash at the end of the source-location validator for non-directory locations.  This allows us to use locations like `url:http://some/where/else`.